### PR TITLE
fix ray head no-monitor param

### DIFF
--- a/examples/llm_fine_tuning/deploy/ray-cluster.yaml
+++ b/examples/llm_fine_tuning/deploy/ray-cluster.yaml
@@ -31,7 +31,6 @@ spec:
   headGroupSpec:
     rayStartParams:
       dashboard-host: "0.0.0.0"
-      no-monitor: ""
     template:
       metadata:
         annotations:


### PR DESCRIPTION
- KubeRay renders no-monitor as --no-monitor= which Ray 2.54 rejects
- That crashes the Ray head and blocks a fresh make infra and deploy
- The cluster uses fixed replicas so the param is unnecessary and removed